### PR TITLE
Add LearnerRelationship model.

### DIFF
--- a/classes/Entities/LearnerRelationship.php
+++ b/classes/Entities/LearnerRelationship.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace local\learner_relationships\Entities;
+
+use Avado\MoodleAbstractionLibrary\Entities\BaseModel;
+use Avado\MoodleAbstractionLibrary\Entities\Role;
+use Avado\MoodleAbstractionLibrary\Entities\User;
+
+/**
+ * Class LearnerRelationship
+ *
+ * @package local\learner_relationships\Entities
+ */
+class LearnerRelationship extends BaseModel
+{
+    /**
+     * @var string
+     */
+    protected $table = 'lr_learner_relationships';
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'relationship_id', 'id');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function role()
+    {
+        return $this->hasOne(Role::class, 'id', 'role_id');
+    }
+}


### PR DESCRIPTION
Temp solution to lack of cross plugin dependency injection for Digital Apprenticeship work.

Currently 'Event Calendar' & 'Apprentice Dashboards' require access to the Learner Relationships records. Until we fix the cross plugin dependency issue this is the cleanesst way to provide access. 