### PR TITLE
Fix order of relationship params

### DIFF
--- a/classes/Entities/Role.php
+++ b/classes/Entities/Role.php
@@ -13,7 +13,7 @@ class Role extends BaseModel
 
     public function enrol()
     {
-        return $this->belongsTo(Enrol::class, 'roleid', 'id');
+        return $this->belongsTo(Enrol::class, 'id', 'roleid');
     }
 
     public function overrides()


### PR DESCRIPTION
The second argument in belongsTo() should be the foreign key in the Entity table (in this case Role), the third is the matching field in the relationship table (Enrol)