### PR TITLE
feat(search): Add sort functionality to controller search

### DIFF
--- a/classes/Routing/Controller/Controller.php
+++ b/classes/Routing/Controller/Controller.php
@@ -93,6 +93,7 @@ abstract class Controller
             }
         }
         $resources = $this->addRelationshipsToSearch($resources, $this->request->get('strict'));
+        $resources = $this->addOrderByToSearch($resources);
 
         return $resources;
     }
@@ -164,5 +165,24 @@ abstract class Controller
         $paginationFields = ['page','offset','limit','relationships','strict'];
 
         return array_diff_key($queryParameters, array_flip($paginationFields));
+    }
+
+    /**
+     * @param Builder $resources
+     * @return Builder
+     */
+    protected function addOrderByToSearch(Builder $resources): Builder
+    {
+        $searchParams = preg_grep('/sortAsc|sortDesc/', array_keys($this->request->query->all()));
+
+        foreach ($searchParams as $searchParam) {
+            $orderBy = $searchParam == 'sortAsc' ? 'orderBy' : 'orderByDesc';
+
+            foreach (explode(',', $this->request->get($searchParam)) as $sortable) {
+                $resources->$orderBy($sortable);
+            }
+        }
+
+        return $resources;
     }
 }


### PR DESCRIPTION
Adds order functionality to controller search which is going to be required in various projects (such as course versioning).

Implementation assigns order by in same order passed in URL so the below request...

/api/index.php/users?sortDesc=timecreated&sortAsc=lastname,firstname

sorts first by time created in decending order, then lastname, then firstname, both in ascending order. 

The param argument names can be changed if we think there is a more appropriate option, ive currently gone by the general 'sort' standard with directionality added. 