### PR TITLE
fix: Added condition to narrow down the hasPermission checks for the …

### DIFF
--- a/classes/Entities/ACL/User.php
+++ b/classes/Entities/ACL/User.php
@@ -42,6 +42,6 @@ class User extends BaseModel
     {
         return $this->whereHas('roles.permissions', function($query) use ($permission){
             $query->where('name', $permission);
-        })->exists();
+        })->where('id', $this->id)->exists();
     }
 }


### PR DESCRIPTION
at the moment the hasPermission check is not specific to the logged-in user. to achieve it we have to add where condition within the lookup to narrow down it to the logged-in user id.
i.e
select * from "avado_mdl_user" where exists (select * from "avado_mdl_acl_roles" inner join "avado_mdl_acl_user_roles" on "avado_mdl_acl_user_roles"."role_id" = "avado_mdl_acl_roles"."id" where "avado_mdl_user"."id" = "avado_mdl_acl_user_roles"."user_id" and exists (select * from "avado_mdl_acl_permissions" inner join "avado_mdl_acl_role_permissions" on "avado_mdl_acl_role_permissions"."permission_id" = "avado_mdl_acl_permissions"."id" where "avado_mdl_acl_roles"."id" = "avado_mdl_acl_role_permissions"."role_id" and "name" = 'coursesections-admin')) **and "id" = 2**       