### PR TITLE
Relationship save changes

### DIFF
--- a/classes/Entities/BaseModel.php
+++ b/classes/Entities/BaseModel.php
@@ -195,6 +195,34 @@ class BaseModel extends Model
     }
 
     /**
+     * Register a single observer with the model.
+     *
+     * @param  object|string  $class
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    protected function registerObserver($class)
+    {
+        foreach ($this->getObservableEvents() as $event) {
+            if (method_exists($class, $event) && !$this->isObserved($event)) {
+                static::registerModelEvent($event, $class.'@'.$event);
+            }
+        }
+    }
+
+    /**
+     * Checks to see if the current event is already registered.
+     *
+     * @param String $event
+     * @return bool
+     */
+    protected function isObserved(String $event): bool
+    {
+        return static::$dispatcher->hasListeners("eloquent.{$event}: ".static::class);
+    }
+
+    /**
      * Dynamically set attributes on the model.
      *
      * @param  string  $key

--- a/classes/Entities/BaseModel.php
+++ b/classes/Entities/BaseModel.php
@@ -14,6 +14,7 @@ use Symfony\Component\Translation\Translator;
 use Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory;
 use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
 use Doctrine\Common\Annotations\AnnotationReader;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * Class BaseModel

--- a/classes/Entities/BaseModel.php
+++ b/classes/Entities/BaseModel.php
@@ -118,6 +118,22 @@ class BaseModel extends Model
     }
 
     /**
+     * Update the model in the database.
+     *
+     * @param  array  $attributes
+     * @param  array  $options
+     * @return bool
+     */
+    public function update(array $attributes = [], array $options = [])
+    {
+        if (! $this->exists) {
+            return false;
+        }
+
+        return $this->fill($attributes)->save($options);
+    }
+
+    /**
      * Fill the model with an array of attributes.
      *
      * @param  array  $attributes

--- a/classes/Observers/AbstractObserver.php
+++ b/classes/Observers/AbstractObserver.php
@@ -11,7 +11,7 @@ abstract class AbstractObserver
     public function listen(array $events, array $arguments): bool
     {
         foreach ($events as $event) {
-            if($event->check()){
+            if($event->check($arguments)){
                 $event->handle($arguments);
             }
         }


### PR DESCRIPTION
Couple of changes in here:

1) $arguments array now passed to check() function in Abstract Observer so It can perform checks as intended.

2) Override registerObserver (origonally in HasEvents Class) so we can add check before registering an observer. This was previously happening many times for the same Event causing issues. Now we simply check the Event isn't already registered before doing it again. 

3) Move update() from Model into BaseModel. We have extended save() and this was being bypassed by update.

These changes are being directly introduced to the /api directory through https://bitbucket.org/avadolearning/alp/branch/CleanAssessmentData/v1.0.0/DEV-10259