### PR TITLE
DEV-11134 fixed reserve character from API Request

### DIFF
--- a/classes/Routing/RoutingBootstrapService.php
+++ b/classes/Routing/RoutingBootstrapService.php
@@ -222,12 +222,10 @@ class RoutingBootstrapService
     protected function encodeQueryParams(Request $request): void
     {
         $encodedQueryKeys = array_map(function ($requestKeys) {
-            if (preg_match('/%([a-zA-Z].*?)%\d+/', urlencode($requestKeys), $escapeString) == 1) {
-                return str_replace(
-                    $escapeString[0],
-                    '%' . ucfirst(strtolower($escapeString[1])) . '%',
-                    urlencode($requestKeys)
-                );
+            if (preg_match('/[^\\w^%]+/', $requestKeys, $nonWordCharacter) == 1) {
+                $searchString = [$nonWordCharacter[0], '_'];
+                $replaceString = [ucwords(strtolower(urlencode($nonWordCharacter[0])), '%'), ' '];
+                return str_replace($searchString, $replaceString, $requestKeys);
             }
             return $requestKeys;
         }, $request->query->keys());

--- a/classes/Routing/RoutingBootstrapService.php
+++ b/classes/Routing/RoutingBootstrapService.php
@@ -224,7 +224,7 @@ class RoutingBootstrapService
         $encodedQueryKeys = array_map(function ($requestKeys) {
             if (preg_match('/[^\\w^%]+/', $requestKeys, $nonWordCharacter) == 1) {
                 $searchString = [$nonWordCharacter[0], '_'];
-                $replaceString = [ucwords(strtolower(urlencode($nonWordCharacter[0])), '%'), ' '];
+                $replaceString = [strtolower(urlencode($nonWordCharacter[0])), ' '];
                 return str_replace($searchString, $replaceString, $requestKeys);
             }
             return $requestKeys;

--- a/classes/Routing/RoutingBootstrapService.php
+++ b/classes/Routing/RoutingBootstrapService.php
@@ -26,6 +26,7 @@ use Doctrine\Common\Annotations\DocParser;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Avado\MoodleAbstractionLibrary\Listeners\MagicControllerArgumentsListener;
 use Avado\MoodleAbstractionLibrary\Listeners\AttachModelRelationshipsListener;
+
 // use Avado\MoodleAbstractionLibrary\Validation\Constraints\UniqueEntity;
 
 // $uniqueEntity = new UniqueEntity();
@@ -63,13 +64,16 @@ class RoutingBootstrapService
      * @param string $controllersPath
      * @param string $cacheDir
      */
-    public function __construct(string $componentDirectory, bool $useEventsAndMiddleware = false, string $cacheRoutingDirectory = null)
-    {
+    public function __construct(
+        string $componentDirectory,
+        bool $useEventsAndMiddleware = false,
+        string $cacheRoutingDirectory = null
+    ) {
         $this->componentDirectory = $componentDirectory;
         $this->useEventsAndMiddleware = $useEventsAndMiddleware;
         $this->cacheRoutingDirectory = $cacheRoutingDirectory;
     }
-    
+
     /**
      *
      */
@@ -89,29 +93,32 @@ class RoutingBootstrapService
                 $_SERVER,
                 null
             );
-
+            $this->encodeQueryParams($request);
             $httpKernel = new HttpKernel(
                 $this->buildEventDispatcher(),
                 new MoodleControllerResolver(null, $this->componentDirectory, $request)
             );
 
-            if($this->useEventsAndMiddleware){
+            if ($this->useEventsAndMiddleware) {
                 try {
                     $this->passThroughMiddleware($request, $httpKernel);
-    
-                } catch (HttpException $e){
-                    (new JsonResponse(['success'=>'false','message'=>$e->getMessage()]))->send();die;
+
+                } catch (HttpException $e) {
+                    (new JsonResponse(['success' => 'false', 'message' => $e->getMessage()]))->send();
+                    die;
                 }
             }
             $response = $httpKernel->handle($request)->send();
-            
+
         } catch (ResourceNotFoundException $e) {
-            (new JsonResponse(['success'=>'false','message'=> $e->getMessage()]))->send();die;
-        } catch (\Exception $e){
-            (new JsonResponse(['success'=>'false','message'=> $e->getMessage()]))->send();die;
+            (new JsonResponse(['success' => 'false', 'message' => $e->getMessage()]))->send();
+            die;
+        } catch (\Exception $e) {
+            (new JsonResponse(['success' => 'false', 'message' => $e->getMessage()]))->send();
+            die;
         }
     }
-    
+
     /**
      * @return null
      */
@@ -122,7 +129,7 @@ class RoutingBootstrapService
         }
         return $this->router;
     }
-    
+
     /**
      * @return AnnotationDirectoryLoader
      */
@@ -144,7 +151,7 @@ class RoutingBootstrapService
         }
         return $this->requestContext;
     }
-    
+
     /**
      * @return Router
      */
@@ -152,8 +159,8 @@ class RoutingBootstrapService
     {
         return new Router(
             $this->getLoader(),
-            $this->componentDirectory.'/classes',
-            ['cache_dir'=> $this->cacheRoutingDirectory],
+            $this->componentDirectory . '/classes',
+            ['cache_dir' => $this->cacheRoutingDirectory],
             $this->getRequestContext()
         );
     }
@@ -167,7 +174,7 @@ class RoutingBootstrapService
         $requestContext->fromRequest(Request::createFromGlobals());
         return $requestContext;
     }
-    
+
     /**
      * @param $request
      */
@@ -179,7 +186,7 @@ class RoutingBootstrapService
             ACLMiddleware::class,
             ResourceCacheMiddleware::class
         ];
-        foreach ($middlewares as $middleware){
+        foreach ($middlewares as $middleware) {
             $middleware = (new Container($this->componentDirectory))->get($middleware);
             $middleware->handle($request, $httpKernel);
         }
@@ -191,7 +198,7 @@ class RoutingBootstrapService
      */
     protected function buildEventDispatcher()
     {
-        if(!$this->useEventsAndMiddleware){
+        if (!$this->useEventsAndMiddleware) {
             return new EventDispatcher();
         }
 
@@ -199,7 +206,7 @@ class RoutingBootstrapService
         $httpCacheListener = new HttpCacheListener();
         $magicArgumentsListener = new MagicControllerArgumentsListener();
         $attachRelationshipsListener = new AttachModelRelationshipsListener();
-        
+
         $eventDispatcher = new EventDispatcher();
         $eventDispatcher->addSubscriber($controllerListener);
         $eventDispatcher->addSubscriber($httpCacheListener);
@@ -207,5 +214,26 @@ class RoutingBootstrapService
         $eventDispatcher->addSubscriber($attachRelationshipsListener);
 
         return $eventDispatcher;
+    }
+
+    /**
+     * Filter the Query Parameter for any Non-Ascii character
+     *
+     * @param Request $request
+     */
+    protected function encodeQueryParams(Request $request): void
+    {
+        $encodedQueryKeys = array_map(function ($requestKeys) {
+            if (preg_match('/%([a-zA-Z].*?)%\d+/', urlencode($requestKeys), $escapeString) == 1) {
+                return str_replace(
+                    $escapeString[0],
+                    '%' . ucfirst(strtolower($escapeString[1])) . '%',
+                    urlencode($requestKeys)
+                );
+            }
+            return $requestKeys;
+        }, $request->query->keys());
+
+        $request->query->replace(array_combine($encodedQueryKeys, $request->query->all()));
     }
 }

--- a/classes/Routing/RoutingBootstrapService.php
+++ b/classes/Routing/RoutingBootstrapService.php
@@ -105,14 +105,12 @@ class RoutingBootstrapService
 
                 } catch (HttpException $e) {
                     (new JsonResponse(['success' => 'false', 'message' => $e->getMessage()]))->send();
-                    die;
                 }
             }
             $response = $httpKernel->handle($request)->send();
 
         } catch (ResourceNotFoundException $e) {
             (new JsonResponse(['success' => 'false', 'message' => $e->getMessage()]))->send();
-            die;
         } catch (\Exception $e) {
             (new JsonResponse(['success' => 'false', 'message' => $e->getMessage()]))->send();
             die;


### PR DESCRIPTION
Sometimes when we try to hit API request some reserve character cause an issue with search result as this reserved character can't be encoded in Request method, Here are some sample API's which result in causing errors

1. http://avado.local/api/index.php/users?firstnameLIKE%ben%
2. http://avado.local/api/index.php/users?firstnameLIKE%Admin%

Basically %A, %B is a reserved character which can't decode properly,
Reference link which lists down reserve character https://www.php.net/manual/en/function.urlencode.php#97969
This PR will fix those character encoding issue