### PR TITLE
feat(DEV-11168): Added support for filterSearch in API controller

### DIFF
--- a/classes/Routing/Controller/Controller.php
+++ b/classes/Routing/Controller/Controller.php
@@ -85,7 +85,7 @@ abstract class Controller
     {
         if ($this->checkIfSearchFieldsDefined()) {
             $queryResource = new QueryResourceService($this->request);
-            return $queryResource->search((get_class($this))::MODEL);
+            return $queryResource->search((get_class($this))::MODEL, $this);
         } else {
             (static::MODEL)::setPrivileged($this->isStaff($this->request));
             $resources = (static::MODEL)::query();
@@ -108,6 +108,7 @@ abstract class Controller
                 }
             }
             $resources = $this->addRelationshipsToSearch($resources, $this->request->get('strict'));
+            $resources = method_exists($this, 'filterSearch') ? $this->filterSearch($resources) : $resources;
             $resources = $this->addSortByToSearch($resources);
 
             return $resources;

--- a/classes/Services/QueryResourceService.php
+++ b/classes/Services/QueryResourceService.php
@@ -4,6 +4,7 @@ namespace Avado\MoodleAbstractionLibrary\Services;
 
 use Avado\MoodleAbstractionLibrary\Database\Builder;
 use Symfony\Component\HttpFoundation\Request;
+use Avado\MoodleAbstractionLibrary\Routing\Controller\Controller;
 use Avado\MoodleAbstractionLibrary\Traits\ChecksUserIsPrivileged;
 
 /**
@@ -47,16 +48,18 @@ class QueryResourceService
 
     /**
      * @param string $model
+     * @param Controller $controller
      * @return Builder|mixed
      * @throws \Exception
      */
-    public function search(string $model)
+    public function search(string $model, Controller $controller)
     {
         $this->route = 'search';
         ($model)::setPrivileged($this->isStaff($this->request));
         $queryParameters = $this->getConstraints();
         $resources = $this->queryConstraints(($model)::query(), $queryParameters[0], [$model]);
         $resources = $this->addRelationshipsToSearch($resources, $queryParameters[1], $model);
+        $resources = method_exists($controller, 'filterSearch') ? $controller->filterSearch($resources) : $resources;
         return $this->addSortByToSearch($resources);
     }
 


### PR DESCRIPTION
Added feature for API controller, to filter out the resource, so that In Search request we can have more controller on resultset.
https://app.asana.com/0/1159860583199675/1193671970132049

Please refer doc for more details
https://avadolearning.atlassian.net/wiki/spaces/ALP/pages/442466305/How+to+add+filter+in+search+API+s