### PR TITLE
feat(Notifications): ...

### DIFF
--- a/classes/Entities/Message.php
+++ b/classes/Entities/Message.php
@@ -2,16 +2,25 @@
 
 namespace Avado\MoodleAbstractionLibrary\Entities;
 
+use Avado\MoodleAbstractionLibrary\Observers\MessageObserver;
+
 /**
  * Class Message
  * @package Avado\MoodleAbstractionLibrary\Entities
  */
 class Message extends BaseModel
 {
+    const OBSERVER = MessageObserver::class;
+
     /**
      * @var string
      */
     protected $table = 'message';
+
+    /**
+     * @var array
+     */
+    protected $guarded = ['id'];
 
     /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/classes/Entities/Notification.php
+++ b/classes/Entities/Notification.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Avado\MoodleAbstractionLibrary\Entities;
+
+use Avado\MoodleAbstractionLibrary\Entities\BaseModel;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * Class Notification
+ * @package Avado\AlpApi\Notifications\Entities
+ */
+class Notification extends BaseModel
+{
+    use SoftDeletes;
+
+    /**
+     * @var array
+     */
+    const SEARCH_FIELDS = [
+        'id',
+        'from_user_id',
+        'to_user_id',
+        'is_read',
+        'component_id',
+        'event_type_id',
+        'contexturl',
+        'contexturlname',
+        'notification_type_id',
+        'should_email'
+    ];
+
+    /**
+     * @var array
+     */
+    public const CHILDREN = [
+        'sender' => User::class
+    ];
+
+    /**
+     * @var string
+     */
+    protected $table = 'notifications';
+
+    /**
+     * @var bool
+     */
+    public $timestamps = true;
+
+    /**
+     * @var array
+     */
+    protected $guarded = ['id'];
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function recipient()
+    {
+        return $this->belongsTo(User::class, 'to_user_id', 'id');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function sender()
+    {
+        return $this->belongsTo(User::class, 'from_user_id', 'id');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function component()
+    {
+        return $this->belongsTo(NotificationComponent::class,'component_id', 'id');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function eventType()
+    {
+        return $this->belongsTo(NotificationEventType::class,'event_type_id', 'id');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function notificationType()
+    {
+        return $this->belongsTo(NotificationType::class,'notification_type_id', 'id');
+    }
+}

--- a/classes/Entities/NotificationComponent.php
+++ b/classes/Entities/NotificationComponent.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Avado\MoodleAbstractionLibrary\Entities;
+
+use Avado\MoodleAbstractionLibrary\Entities\BaseModel;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * Class NotificationComponent
+ * @package Avado\AlpApi\Notifications\Entities
+ */
+class NotificationComponent extends BaseModel
+{
+    use SoftDeletes;
+
+    /**
+     * @var string
+     */
+    protected $table = 'notification_components';
+
+    /**
+     * @var bool
+     */
+    public $timestamps = true;
+
+    /**
+     * @var array
+     */
+    protected $guarded = ['id'];
+}

--- a/classes/Entities/NotificationEmailQueue.php
+++ b/classes/Entities/NotificationEmailQueue.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Avado\MoodleAbstractionLibrary\Entities;
+
+use Avado\MoodleAbstractionLibrary\Entities\BaseModel;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * Class NotificationEmailQueue
+ * @package Avado\AlpApi\Notifications\Entities
+ */
+class NotificationEmailQueue extends BaseModel
+{
+    use SoftDeletes;
+
+    /**
+     * @var string
+     */
+    protected $table = 'notification_email_queue';
+
+    /**
+     * @var bool
+     */
+    public $timestamps = true;
+
+    /**
+     * @var array
+     */
+    protected $guarded = ['id'];
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function notification()
+    {
+        return $this->belongsTo(Notification::class, 'notification_id', 'id');
+    }
+}

--- a/classes/Entities/NotificationEventType.php
+++ b/classes/Entities/NotificationEventType.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Avado\MoodleAbstractionLibrary\Entities;
+
+use Avado\MoodleAbstractionLibrary\Entities\BaseModel;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * Class NotificationEventType
+ * @package Avado\AlpApi\Notifications\Entities
+ */
+class NotificationEventType extends BaseModel
+{
+    use SoftDeletes;
+
+    /**
+     * @var string
+     */
+    protected $table = 'notification_event_types';
+
+    /**
+     * @var bool
+     */
+    public $timestamps = true;
+
+    /**
+     * @var array
+     */
+    protected $guarded = ['id'];
+}

--- a/classes/Entities/NotificationMigrationLog.php
+++ b/classes/Entities/NotificationMigrationLog.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Avado\MoodleAbstractionLibrary\Entities;
+
+use Avado\MoodleAbstractionLibrary\Entities\BaseModel;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * Class NotificationMigrationLog
+ * @package Avado\AlpApi\Notifications\Entities
+ */
+class NotificationMigrationLog extends BaseModel
+{
+    use SoftDeletes;
+
+    /**
+     * @var string
+     */
+    protected $table = 'notification_migration_log';
+
+    /**
+     * @var bool
+     */
+    public $timestamps = true;
+
+    /**
+     * @var array
+     */
+    protected $guarded = ['id'];
+
+}

--- a/classes/Entities/NotificationSetting.php
+++ b/classes/Entities/NotificationSetting.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Avado\MoodleAbstractionLibrary\Entities;
+
+use Avado\MoodleAbstractionLibrary\Entities\BaseModel;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * Class NotificationSetting
+ * @package Avado\AlpApi\Notifications\Entities
+ */
+class NotificationSetting extends BaseModel
+{
+    use SoftDeletes;
+
+    /**
+     * @var string
+     */
+    protected $table = 'notification_settings';
+
+    /**
+     * @var array
+     */
+    protected $guarded = ['id'];
+
+    /**
+     * @var bool
+     */
+    public $timestamps = true;
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function eventType()
+    {
+        return $this->belongsTo(NotificationEventType::class,'event_type_id', 'id');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function notificationType()
+    {
+        return $this->belongsTo(NotificationType::class,'notification_type_id', 'id');
+    }
+}

--- a/classes/Entities/NotificationType.php
+++ b/classes/Entities/NotificationType.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Avado\MoodleAbstractionLibrary\Entities;
+
+use Avado\MoodleAbstractionLibrary\Entities\BaseModel;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * Class NotificationType
+ * @package Avado\AlpApi\Notifications\Entities
+ */
+class NotificationType extends BaseModel
+{
+    use SoftDeletes;
+
+    /**
+     * @var string
+     */
+    protected $table = 'notification_types';
+
+    /**
+     * @var bool
+     */
+    public $timestamps = true;
+
+    /**
+     * @var array
+     */
+    protected $guarded = ['id'];
+}

--- a/classes/Events/SaveNotificationOnMessageSaveEvent.php
+++ b/classes/Events/SaveNotificationOnMessageSaveEvent.php
@@ -27,6 +27,10 @@ class SaveNotificationOnMessageSaveEvent extends AbstractEvent
      */
     protected $logger;
 
+    /**
+     * SaveNotificationOnMessageSaveEvent constructor.
+     * @param Logger $logger
+     */
     public function __construct(Logger $logger)
     {
         $this->logger = $logger;

--- a/classes/Events/SaveNotificationOnMessageSaveEvent.php
+++ b/classes/Events/SaveNotificationOnMessageSaveEvent.php
@@ -9,6 +9,7 @@ use Avado\MoodleAbstractionLibrary\Entities\NotificationEventType;
 use Avado\MoodleAbstractionLibrary\Entities\NotificationSetting;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\QueryException;
+use Monolog\Logger;
 
 /**
  * Class SaveNotificationOnMessageSaveEvent
@@ -20,6 +21,16 @@ class SaveNotificationOnMessageSaveEvent extends AbstractEvent
      * @var bool
      */
     public const QUEUED = false;
+
+    /**
+     * @var Logger
+     */
+    protected $logger;
+
+    public function __construct(Logger $logger)
+    {
+        $this->logger = $logger;
+    }
 
     /**
      * @param array $arguments
@@ -38,7 +49,7 @@ class SaveNotificationOnMessageSaveEvent extends AbstractEvent
     {
         return static::QUEUED ? $this->addToQueue($arguments) : $this->execute($arguments);
     }
-    
+
     /**
      * @param array $arguments
      * @return bool
@@ -68,7 +79,7 @@ class SaveNotificationOnMessageSaveEvent extends AbstractEvent
                     'should_email'         => (int) $shouldEmail
                 ]);
             } catch (QueryException $e) {
-                return false;
+                $this->logger->error("Failed to create Notification in MAL 'SaveNotificationOnMessageSaveEvent': {$e->getTraceAsString()}");
             }
 
             if ($shouldEmail) {
@@ -157,7 +168,7 @@ class SaveNotificationOnMessageSaveEvent extends AbstractEvent
             ]);
             return true;
         } catch (QueryException $e) {
-            return false;
+            $this->logger->error("Failed to add Notification to mail queue in MAL 'SaveNotificationOnMessageSaveEvent': {$e->getTraceAsString()}");
         }
     }
 
@@ -173,7 +184,7 @@ class SaveNotificationOnMessageSaveEvent extends AbstractEvent
                 'status' => 1
             ]);
         } catch (QueryException $e) {
-            return false;
+            $this->logger->error("Failed to create event type in MAL 'SaveNotificationOnMessageSaveEvent': {$e->getTraceAsString()}");
         }
     }
 
@@ -189,7 +200,7 @@ class SaveNotificationOnMessageSaveEvent extends AbstractEvent
                 'status' => 1
             ]);
         } catch (QueryException $e) {
-            return false;
+            $this->logger->error("Failed to create component ID in MAL 'SaveNotificationOnMessageSaveEvent': {$e->getTraceAsString()}");
         }
     }
 }

--- a/classes/Events/SaveNotificationOnMessageSaveEvent.php
+++ b/classes/Events/SaveNotificationOnMessageSaveEvent.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Avado\MoodleAbstractionLibrary\Events;
+
+use Avado\MoodleAbstractionLibrary\Entities\Notification;
+use Avado\MoodleAbstractionLibrary\Entities\NotificationComponent;
+use Avado\MoodleAbstractionLibrary\Entities\NotificationEmailQueue;
+use Avado\MoodleAbstractionLibrary\Entities\NotificationEventType;
+use Avado\MoodleAbstractionLibrary\Entities\NotificationSetting;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\QueryException;
+
+/**
+ * Class SaveNotificationOnMessageSaveEvent
+ * @package Avado\MoodleAbstractionLibrary\Events\AbstractEvent
+ */
+class SaveNotificationOnMessageSaveEvent extends AbstractEvent
+{
+    /**
+     * @var bool
+     */
+    public const QUEUED = false;
+
+    /**
+     * @param array $arguments
+     * @return bool
+     */
+    public function check(array $arguments): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param array $arguments
+     * @return bool
+     */
+    public function handle(array $arguments): bool
+    {
+        return static::QUEUED ? $this->addToQueue($arguments) : $this->execute($arguments);
+    }
+    
+    /**
+     * @param array $arguments
+     * @return bool
+     */
+    public function execute(array $arguments): bool
+    {
+        $message = $arguments['message'];
+
+        $eventTypeId          = $this->getEventTypeId($message->name);
+        $notificationSettings = $this->notificationSettings($message->useridto, $eventTypeId);
+
+        if($notificationSettings->isNotEmpty()) {
+            $shouldEmail = $this->shouldEmail($notificationSettings);
+            try {
+                $notification = Notification::create([
+                    'from_user_id'         => $message->useridfrom,
+                    'to_user_id'           => $message->useridto,
+                    'subject'              => $message->subject,
+                    'content'              => $message->fullmessage,
+                    'html_content'         => $message->fullmessagehtml,
+                    'is_read'              => 0,
+                    'contexturl'           => $message->contexturl ?? null,
+                    'contexturlname'       => $message->contexturlname ?? null,
+                    'component_id'         => $this->getComponentId($message->component),
+                    'event_type_id'        => $eventTypeId,
+                    'notification_type_id' => 1,
+                    'should_email'         => (int) $shouldEmail
+                ]);
+            } catch (QueryException $e) {
+                return false;
+            }
+
+            if ($shouldEmail) {
+                $this->addToMailQueue($notification->id);
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Get event type id from string type. If it doesnt exist add it.
+     *
+     * @param mixed $eventType
+     * @return int
+     */
+    protected function getEventTypeId($eventType): int
+    {
+        $eventType = $eventType == null ? 'nullEventType' : $eventType;
+
+        $eventType = NotificationEventType::where(['name' => $eventType])->first();
+
+        if (!$eventType) {
+            $eventType = $this->createEventType($eventType);
+        }
+
+        return $eventType->id;
+    }
+
+    /**
+     * Get any enabled settings for specified event type against a user
+     *
+     * @param int $userId
+     * @param int $eventTypeId
+     * @return Collection
+     */
+    protected function notificationSettings(int $userId, int $eventTypeId): Collection
+    {
+        return NotificationSetting::where([
+            'user_id'       => $userId,
+            'event_type_id' => $eventTypeId,
+            'is_enabled'    => 1
+        ])->get();
+    }
+
+    /**
+     * Of enabled settings returned for event type, see if any are for email.
+     *
+     * @param Collection $settings
+     * @return bool
+     */
+    protected function shouldEmail(Collection $settings): bool
+    {
+        foreach ($settings as $setting) {
+            if ($setting->notification_type_id == 2) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @param mixed $componentName
+     * @return int
+     */
+    protected function getComponentId($componentName): int
+    {
+        $component = NotificationComponent::where(['name' => $componentName])->first();
+
+        if (!$component) {
+            $component = $this->createComponentId($componentName);
+        }
+
+        return $component->id;
+    }
+
+    /**
+     * @param int $notificationId
+     * @return bool
+     */
+    protected function addToMailQueue(int $notificationId): bool
+    {
+        try {
+            NotificationEmailQueue::create([
+                'notification_id' => $notificationId,
+                'status' => 0
+            ]);
+            return true;
+        } catch (QueryException $e) {
+            return false;
+        }
+    }
+
+    /**
+     * @param string $eventType
+     * @return mixed
+     */
+    protected function createEventType(string $eventType)
+    {
+        try {
+            return NotificationEventType::create([
+                'name' => $eventType,
+                'status' => 1
+            ]);
+        } catch (QueryException $e) {
+            return false;
+        }
+    }
+
+    /**
+     * @param string $componentName
+     * @return mixed
+     */
+    protected function createComponentId(string $componentName)
+    {
+        try {
+            return NotificationComponent::create([
+                'name' => $componentName,
+                'status' => 1
+            ]);
+        } catch (QueryException $e) {
+            return false;
+        }
+    }
+}

--- a/classes/Observers/MessageObserver.php
+++ b/classes/Observers/MessageObserver.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Avado\MoodleAbstractionLibrary\Observers;
+
+use Avado\MoodleAbstractionLibrary\Entities\Message;
+use Avado\MoodleAbstractionLibrary\Events\SaveNotificationOnMessageSaveEvent;
+use Avado\MoodleAbstractionLibrary\Observers\AbstractObserver;
+
+/**
+ * Class MessageObserver
+ * @package Avado\AlpApi\Messages\Observers
+ */
+class MessageObserver extends AbstractObserver
+{
+    /**
+     * @param Message $message
+     */
+    public function saved(Message $message): void
+    {
+        $events = [
+            new SaveNotificationOnMessageSaveEvent()
+        ];
+
+        $this->listen($events, ['message' => $message]);
+    }
+}


### PR DESCRIPTION
 Add Observer/Event to Message Entity to add records to Notification table.

Ive created this as we had been adding content directly to the mdl_message table using Eloquent in local plugins so Event changes to the API Message class didnt cover all instances of ensuring the Notification table was filled where appropriate. 

Relates to this Ticket: https://avadolearning.atlassian.net/browse/DEV-11588